### PR TITLE
Fix build system :: p2 :: Workaround 2G limit

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -190,6 +190,8 @@ jobs:
         uses: actions/download-artifact@v4
       - name: list files
         run: ls -laR .
+      - name: Workaround: Delete all files over 2G, above github release file upload limit
+        run: find . -type f -size +2G -exec rm -v {} \;
       - name: draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -199,7 +199,3 @@ jobs:
           draft: true
           file_glob: true
           file: clang-*/**/*
-        #uses: xresloader/upload-to-github-release@v1.6.0
-        #with:
-          #file: "clang-*/**/*"
-          #draft: true

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -190,7 +190,7 @@ jobs:
         uses: actions/download-artifact@v4
       - name: list files
         run: ls -laR .
-      - name: Workaround: Delete all files over 2G, above github release file upload limit
+      - name: Workaround - delete all files over 2G, above github release file upload limit
         run: find . -type f -size +2G -exec rm -v {} \;
       - name: draft release
         env:


### PR DESCRIPTION
This release infrastructure does not currently allow for artifacts over 2G.  This deletes them before uploading to the github release.